### PR TITLE
Added settings keys sorting

### DIFF
--- a/pages/options.js
+++ b/pages/options.js
@@ -291,7 +291,7 @@ const OptionsPage = {
 
   onDownloadBackupClicked() {
     const backup = Settings.pruneOutDefaultValues(this.getSettingsFromForm());
-    const settingsBlob = new Blob([JSON.stringify(backup, null, 2) + "\n"]);
+    const settingsBlob = new Blob([JSON.stringify(backup, Object.keys(backup).sort(), 2) + "\n"]);
     document.querySelector("#download-backup").href = URL.createObjectURL(settingsBlob);
   },
 


### PR DESCRIPTION
I'm using Git to store my dotfiles and share them between several hosts.
Sometimes, on different hosts, I'm getting the keys in vimium-options.json in a different order.
This makes it difficult to understand exactly what was changed (while in reality, it could be just one line), and also makes diffs larger.
As a solution, I suggest always sort the keys of the settings object.